### PR TITLE
Add mysql multi-source replication parameter

### DIFF
--- a/check_mysql_slavestatus.sh
+++ b/check_mysql_slavestatus.sh
@@ -60,10 +60,10 @@
 # 2019082203 Use default port 3306, makes -P optional                   #
 # 2019082204 Fix moving subcheck, improve documentation                 #
 #########################################################################
-# Usage: ./check_mysql_slavestatus.sh (-o file|(-H dbhost [-P port]|-S socket) -u dbuser -p dbpass) [-s connection] [-w integer] [-c integer] [-m integer]
+# Usage: ./check_mysql_slavestatus.sh (-o file|(-H dbhost [-P port]|-S socket) -u dbuser -p dbpass) [-s connection] [-C channel] [-w integer] [-c integer] [-m integer]
 #########################################################################
 help="\ncheck_mysql_slavestatus.sh (c) 2008-2019 GNU GPLv2 licence
-Usage: $0 (-o file|(-H dbhost [-P port]|-S socket) -u username -p password) ([-s connection]|[-C channel] ) [-w integer] [-c integer] [-m]\n
+Usage: $0 (-o file|(-H dbhost [-P port]|-S socket) -u username -p password) ([-s connection]|[-C channel]) [-w integer] [-c integer] [-m]\n
 Options:\n-o Path to option file containing connection settings (e.g. /home/nagios/.my.cnf). Note: If this option is used, -H, -u, -p parameters will become optional\n-H Hostname or IP of slave server\n-P MySQL Port of slave server (optional, defaults to 3306)\n-u Username of DB-user\n-p Password of DB-user\n-S database socket\n-s Connection name (optional, with multi-source replication for mariadb)\n-C Channel (optional, with multi-source replication for mysql)\n-w Replication delay in seconds for Warning status (optional)\n-c Replication delay in seconds for Critical status (optional)\n-m Threshold in seconds since when replication did not move (compares the slaves log position)\n
 Attention: The DB-user you type in must have CLIENT REPLICATION rights on the DB-server. Example:\n\tGRANT REPLICATION CLIENT on *.* TO 'nagios'@'%' IDENTIFIED BY 'secret';"
 
@@ -104,7 +104,7 @@ do
         p)      password="${OPTARG}"; export MYSQL_PWD="${OPTARG}";;
         S)      socket="-S ${OPTARG}";;
         s)      connection=\"${OPTARG}\";;
-        C)      channel=" FOR CHANNEL '${OPTARG}'";;
+        C)      channel="FOR CHANNEL '${OPTARG}'";;
         w)      warn_delay=${OPTARG};;
         c)      crit_delay=${OPTARG};;
         o)      optfile="--defaults-extra-file=${OPTARG}";;
@@ -137,21 +137,11 @@ if [[ -n "${connection}" && -n "${channel}" ]]; then
   exit ${STATE_UNKNOWN}
 fi
 
-# Create query
-QUERY="SHOW SLAVE "
-if [[ -n "${connection}" ]]; then
-  QUERY="${QUERY} ${connection} STATUS\G"
-elif [[ -n "${channel}" ]]; then
-  QUERY="${QUERY} STATUS ${channel}\G"
-else 
-  QUERY="${QUERY} STATUS\G"
-fi
-
 # Connect to the DB server and store output in vars
 if [[ -n $socket ]]; then 
-  ConnectionResult=$(mysql ${optfile} ${socket} ${user} -e "${QUERY}" 2>&1)
+  ConnectionResult=$(mysql ${optfile} ${socket} ${user} -e "SHOW SLAVE ${connection} STATUS ${channel}\G" 2>&1)
 else
-  ConnectionResult=$(mysql ${optfile} ${host} ${port} ${user} -e "${QUERY}" 2>&1)
+  ConnectionResult=$(mysql ${optfile} ${host} ${port} ${user} -e "SHOW SLAVE ${connection} STATUS ${channel}\G" 2>&1)
 fi
 
 if [ -z "`echo "${ConnectionResult}" |grep Slave_IO_State`" ]; then
@@ -165,8 +155,15 @@ delayinfo=`echo "${ConnectionResult}" |grep Seconds_Behind_Master: | awk '{print
 readpos=`echo "${ConnectionResult}" |grep Read_Master_Log_Pos: | awk '{print $2}'`
 execpos=`echo "${ConnectionResult}" |grep Exec_Master_Log_Pos: | awk '{print $2}'`
 
+multi=(${masterinfo})
+masternum="${#multi[@]}"
+
 # Output of different exit states
 #########################################################################
+if [ $masternum -gt 1 ]; then
+echo "CRITICAL:  Multiple master detected, please use the connection or channel parameter."; exit ${STATE_UNKNOWN};
+fi
+
 if [ ${check} = "NULL" ]; then
 echo "CRITICAL: Slave_SQL_Running is answering NULL"; exit ${STATE_CRITICAL};
 fi
@@ -187,7 +184,7 @@ if [ ${check} = ${ok} ] && [ ${checkio} = ${ok} ]; then
  # Delay thresholds are set
  if [[ -n ${warn_delay} ]] && [[ -n ${crit_delay} ]]; then
   if ! [[ ${warn_delay} -gt 0 ]]; then echo "Warning threshold must be a valid integer greater than 0"; exit $STATE_UNKNOWN; fi
-  if ! [[ ${crit_delay} -gt 0 ]]; then echo "Warning threshold must be a valid integer greater than 0"; exit $STATE_UNKNOWN; fi
+  if ! [[ ${crit_delay} -gt 0 ]]; then echo "Critical threshold must be a valid integer greater than 0"; exit $STATE_UNKNOWN; fi
   if [[ -z ${warn_delay} ]] || [[ -z ${crit_delay} ]]; then echo "Both warning and critical thresholds must be set"; exit $STATE_UNKNOWN; fi
   if [[ ${warn_delay} -gt ${crit_delay} ]]; then echo "Warning threshold cannot be greater than critical"; exit $STATE_UNKNOWN; fi
 


### PR DESCRIPTION
Hi,

I intended to use its plugin to verify the replication of mysql with multi-source replication and I discovered that this does not seem to work correctly at least with mysql.
After a little research, I discovered that the correct syntax for mysql is quite different from the mariadb implementation:

mariadb: `show slave 'connection' status`
mysql: `show slave status for channel 'channel'`

So I added a new parameter to indicate when is a mysql (-C) multi-source replication.

A variable verification was also added for the -s and -C parameters, since they are mutually exclusive, as well as a verification when there are more than one slave status response and there is no connection or channel parameter used to avoid the error message: `bash: [: too many arguments`.

I am already using this implementation on my servers and it seems to work correctly.

Please, check the code and if it is useful, you can merge to improve this excellent complement, I will be waiting for any comments.

regards